### PR TITLE
Use Sender's Name instead of Object

### DIFF
--- a/src/main/java/net/lazlecraft/hubkick/HubKick.java
+++ b/src/main/java/net/lazlecraft/hubkick/HubKick.java
@@ -54,7 +54,7 @@ public class HubKick extends JavaPlugin implements Listener {
 		    		if (sender.getServer().getPlayer(args[0]) != null) {
 		    			Player p = sender.getServer().getPlayer(args[0]);
 		    			String server = args[1];
-		    			p.sendMessage(prefix + ChatColor.GREEN + "You were sent to " + server + " by " + sender);
+		    			p.sendMessage(prefix + ChatColor.GREEN + "You were sent to " + server + " by " + sender.getName());
 		    			sendTo(p, server);
 		    		}
 		    		else sender.sendMessage(prefix + ChatColor.RED + "The player you're trying to send is offline!");


### PR DESCRIPTION
Actually get the sender's name and send it instead of relying on sender.toString()
